### PR TITLE
enable drop of csv file

### DIFF
--- a/client/factory.coffee
+++ b/client/factory.coffee
@@ -64,6 +64,9 @@ window.plugins.factory =
       readFile = (file) ->
         if file?
           [majorType, minorType] = file.type.split("/")
+          if file.name.toLowerCase().match(/\.csv$/)
+            majorType = 'text'
+            minorType = 'csv'
           reader = new FileReader()
           if majorType == "image"
             reader.onload = (loadEvent) ->


### PR DESCRIPTION
On Windows, in Chrome, a csv file dropped onto the factory from the filesystem shows up as application/vnd.ms-excel and so fails to ingest. This hack seems to enable me to ingest the data. 

Please consider this more of a modest proposal than a pull request, I'm just using the PR as a convenient mechanism to illustrate/discuss. I'm not sure how this plays out on Mac or Linux, in other browsers, etc., I can't see a downside to overriding when a file has a .csv extension, but there are plenty of things I can't see.

(Also I just freestyled the CoffeeScript, what I tested was written directly in JS.)

Separately I looked at dropping a .csv file from a non-federation webserver. That fails for a different reason: there isn't a handler for non-federation URLs. 

https://github.com/fedwiki/wiki-client/blob/master/lib/drop.coffee#L17
https://github.com/fedwiki/wiki-client/blob/master/lib/factory.coffee#L129

It's more than a 2-liner to change that behavior, but I just want to bookmark it here for future reference.